### PR TITLE
Update html-acct-table.scm

### DIFF
--- a/src/report/report-system/html-acct-table.scm
+++ b/src/report/report-system/html-acct-table.scm
@@ -1162,6 +1162,9 @@
 	   )
 	  )
 	 )))
+    ;;below line as fix to Bug 776396 - make sure the commidity aligns the same as the rest of the currency (on the right)
+    (gnc:html-table-set-style! table "table" 'attribute(list "style" "width:100%; max-width:20em"))
+    ;;end fix
     table)
   )
 


### PR DESCRIPTION
Fix Bug 776396 with proposed change (use css to set table to 100% of the width). Includes the max widt.